### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3157,7 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-terminal"
-version = "0.1.1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6482e31dea39e52c7058384f89fe0b4b054b1216d4103218ae7295d9a9c716f3"
 dependencies = [
  "portable-pty",
  "schemars",
@@ -3405,7 +3407,7 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tattoy"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bytemuck",
  "clap",
@@ -3432,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "tattoy-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bon",
  "serde",

--- a/crates/tattoy-plugins/inverter/Cargo.toml
+++ b/crates/tattoy-plugins/inverter/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-tattoy-protocol = { path = "../../tattoy-protocol", version = "0.1.0" }
+tattoy-protocol = { path = "../../tattoy-protocol", version = "0.1.1" }
 serde_json.workspace = true
 
 [[bin]]

--- a/crates/tattoy-plugins/smokey_cursor/Cargo.toml
+++ b/crates/tattoy-plugins/smokey_cursor/Cargo.toml
@@ -13,7 +13,7 @@ rand.workspace = true
 rayon = "1.10.0"
 rstar = "0.12.0"
 serde_json.workspace = true
-tattoy-protocol = { path = "../../tattoy-protocol", version = "0.1.0"}
+tattoy-protocol = { path = "../../tattoy-protocol", version = "0.1.1" }
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/tattoy-protocol/CHANGELOG.md
+++ b/crates/tattoy-protocol/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/tattoy-org/tattoy/compare/tattoy-protocol-v0.1.0...tattoy-protocol-v0.1.1) - 2025-07-02
+
+### Other
+
+- *(deps)* update Wezterm dependencies
+- v0.1.2

--- a/crates/tattoy-protocol/Cargo.toml
+++ b/crates/tattoy-protocol/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tattoy-protocol"
 description = "Types to help with writing Rust-based Tattoy plugins"
 documentation = "https://docs.rs/tattoy-protocol"
-version = "0.1.0"
+version = "0.1.1"
 license = "MIT"
 edition = "2021"
 

--- a/crates/tattoy/CHANGELOG.md
+++ b/crates/tattoy/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.4](https://github.com/tattoy-org/tattoy/compare/tattoy-v0.1.3...tattoy-v0.1.4) - 2025-07-02
+
+### Other
+
+- update to shadow-terminal v0.2.0
+- migrated Shadow Terminal into its own repo
+- *(deps)* update Wezterm dependencies

--- a/crates/tattoy/Cargo.toml
+++ b/crates/tattoy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tattoy"
 description = "Text-based compositor for modern terminals"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/tattoy-org/tattoy"
@@ -25,7 +25,7 @@ rand.workspace = true
 shadow-terminal.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tattoy-protocol = { path = "../tattoy-protocol", version = "0.1.0" }
+tattoy-protocol = { path = "../tattoy-protocol", version = "0.1.1" }
 tempfile.workspace = true
 tokio.workspace = true
 toml = "0.8.20"


### PR DESCRIPTION



## 🤖 New release

* `tattoy-protocol`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `tattoy`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `tattoy-protocol`

<blockquote>

## [0.1.1](https://github.com/tattoy-org/tattoy/compare/tattoy-protocol-v0.1.0...tattoy-protocol-v0.1.1) - 2025-07-02

### Other

- *(deps)* update Wezterm dependencies
- v0.1.2
</blockquote>

## `tattoy`

<blockquote>

## [0.1.4](https://github.com/tattoy-org/tattoy/compare/tattoy-v0.1.3...tattoy-v0.1.4) - 2025-07-02

### Other

- update to shadow-terminal v0.2.0
- migrated Shadow Terminal into its own repo
- *(deps)* update Wezterm dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).