### PR TITLE
ci: strip 'tattoy-v' from AUR version

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -138,7 +138,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Write release version
         run: |
-          TATTOY_VERSION=${GITHUB_REF_NAME#v}
+          TATTOY_VERSION=${GITHUB_REF_NAME#tattoy-v}
           echo Tattoy version: $TATTOY_VERSION
           echo "TATTOY_VERSION=$TATTOY_VERSION" >> $GITHUB_ENV
       - name: Update AUR package files


### PR DESCRIPTION
This fixes the AUR publishing builds.