### PR TITLE
ci: update .deb and .rpm filenames to match new release syntax

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -92,12 +92,12 @@ jobs:
             --strip \
             --package tattoy \
             --verbose \
-            --output tattoy-${{ github.ref_name }}.deb
+            --output ${{ github.ref_name }}.deb
       - name: Upload .deb to the release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: tattoy-${{ github.ref_name }}.deb
+          file: ${{ github.ref_name }}.deb
           tag: ${{ github.ref_name }}
 
   publish-rpm:
@@ -121,12 +121,12 @@ jobs:
           cargo build --release --locked --package tattoy
           cargo generate-rpm \
             --package crates/tattoy \
-            --output tattoy-${{ github.ref_name }}.x86_64.rpm
+            --output ${{ github.ref_name }}.x86_64.rpm
       - name: Upload the release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: tattoy-${{ github.ref_name }}.x86_64.rpm
+          file: ${{ github.ref_name }}.x86_64.rpm
           tag: ${{ github.ref }}
 
   publish-aur:

--- a/crates/tattoy/Cargo.toml
+++ b/crates/tattoy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tattoy"
 description = "Text-based compositor for modern terminals"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 readme = "../../README.md"
 repository = "https://github.com/tattoy-org/tattoy"

--- a/website/content/download.md
+++ b/website/content/download.md
@@ -15,13 +15,13 @@ Tattoy has prebuilt binaries for both x86 and ARM architectures on all the 3 maj
 
 ### Ubuntu, Debian
 ```sh
-curl -LO https://github.com/tattoy-org/tattoy/releases/download/v{{ include(path='build-vars/version') }}/tattoy-v{{ include(path='build-vars/version') }}.deb
+curl -LO https://github.com/tattoy-org/tattoy/releases/download/tattoy-v{{ include(path='build-vars/version') }}/tattoy-v{{ include(path='build-vars/version') }}.deb
 sudo dpkg --install tattoy-v{{ include(path='build-vars/version') }}.deb
 ```
 
 ### Fedora, RHEL
 ```sh
-sudo dnf install https://github.com/tattoy-org/tattoy/releases/download/v{{ include(path='build-vars/version') }}/tattoy-v{{ include(path='build-vars/version') }}.x86_64.rpm
+sudo dnf install https://github.com/tattoy-org/tattoy/releases/download/tattoy-v{{ include(path='build-vars/version') }}/tattoy-v{{ include(path='build-vars/version') }}.x86_64.rpm
 ```
 
 ### Homebrew


### PR DESCRIPTION
Fixes: #121